### PR TITLE
setting state after completion of generic rule

### DIFF
--- a/rules/rulesCurrent/shared/05_Workflows/SELECTIONS_BEG/10_SendApplicationsForSelectedBEG.drl
+++ b/rules/rulesCurrent/shared/05_Workflows/SELECTIONS_BEG/10_SendApplicationsForSelectedBEG.drl
@@ -75,6 +75,9 @@ rule "Send Applications For Selected BEG"
 		        rules.publishBaseEntityByCode(apps, parent, linkCode, recipients, "APPLICATION", false, false, 2);
 		    }
         }
+        
+        /* setting this state so that project-specific rules can follow up on this state */
+        rules.setState("SELECTED_BEG_PROPERTY");
 
 	 	rules.footer();      
 end

--- a/rules/rulesCurrent/shared/05_Workflows/SELECTIONS_BEG/10_SendApplicationsForSelectedBEG.drl
+++ b/rules/rulesCurrent/shared/05_Workflows/SELECTIONS_BEG/10_SendApplicationsForSelectedBEG.drl
@@ -77,7 +77,7 @@ rule "Send Applications For Selected BEG"
         }
         
         /* setting this state so that project-specific rules can follow up on this state */
-        rules.setState("SELECTED_BEG_PROPERTY");
+        rules.setState("BEG_SELECTED");
 
 	 	rules.footer();      
 end


### PR DESCRIPTION
Tested on Genny Qwanda version 2.0.2

Changes made :
I Set a state at the end of generic BEG-selection rule, so that project-specific rules can run the rest of workflow with this state.
