### PR TITLE
Clear buckets for publishing apps

### DIFF
--- a/rules/rulesCurrent/shared/05_Workflows/SELECTIONS_BEG/10_SendApplicationsForSelectedBEG.drl
+++ b/rules/rulesCurrent/shared/05_Workflows/SELECTIONS_BEG/10_SendApplicationsForSelectedBEG.drl
@@ -32,6 +32,7 @@ rule "Send Applications For Selected BEG"
             		
             		/* we get the parent */
             		BaseEntity parent = rules.baseEntity.getParent(application.getCode(), "LNK_CORE", "GRP_");
+            		rules.println("parent ::"+parent.getCode());
             		if(parent != null) {
             			
             			/* we add the application in the message */
@@ -70,6 +71,9 @@ rule "Send Applications For Selected BEG"
 
 				/* we get the attribute current being used to link BEG -> APP */
 				String linkCode = rules.getProject().getValue("PRI_APPLICATION_LINK_CODE", "LNK_APP");
+				
+				/* Clear the Buckets */
+				rules.publishBaseEntityByCode("GRP_APPLICATIONS", true, 2);
 		        
 		        /* we publish the applications */
 		        rules.publishBaseEntityByCode(apps, parent, linkCode, recipients, "APPLICATION", false, false, 2);

--- a/rules/rulesCurrent/shared/05_Workflows/SELECTIONS_BEG/10_SendApplicationsForSelectedBEG.drl
+++ b/rules/rulesCurrent/shared/05_Workflows/SELECTIONS_BEG/10_SendApplicationsForSelectedBEG.drl
@@ -46,6 +46,9 @@ rule "Send Applications For Selected BEG"
             			parents.put(parent.getCode(), parentApplications);
             		}
             }
+            
+            /* Clear the Buckets */
+			rules.publishBaseEntityByCode("GRP_APPLICATIONS", true, 2);
 
 			/* we replace GRP_APPLICATIONS buckets */
 			List<BaseEntity> branches = rules.baseEntity.getLinkedBaseEntities("GRP_APPLICATIONS", "LNK_CORE");
@@ -57,6 +60,7 @@ rule "Send Applications For Selected BEG"
             
             /* we iterate through our messages */
             Iterator it = parents.entrySet().iterator();
+            
 		    while (it.hasNext()) {
 		        
 		    		Map.Entry pair = (Map.Entry)it.next();
@@ -71,9 +75,6 @@ rule "Send Applications For Selected BEG"
 
 				/* we get the attribute current being used to link BEG -> APP */
 				String linkCode = rules.getProject().getValue("PRI_APPLICATION_LINK_CODE", "LNK_APP");
-				
-				/* Clear the Buckets */
-				rules.publishBaseEntityByCode("GRP_APPLICATIONS", true, 2);
 		        
 		        /* we publish the applications */
 		        rules.publishBaseEntityByCode(apps, parent, linkCode, recipients, "APPLICATION", false, false, 2);


### PR DESCRIPTION
Issue fixed with the change :
On BEG selection, the APPs get appended to the existing APPs from previous BEG selection. Clearing the buckets before publishing APPs fixes this issue.

Tested for PCSS. 

Versions used for testing : 
Genny 2.0.2
Alyson-v3 : 2.0.10
Also tested with PCSS production DB Dump.